### PR TITLE
Moved monitoring 'M' to the right.

### DIFF
--- a/styles/monitor.less
+++ b/styles/monitor.less
@@ -6,12 +6,13 @@
 .file-monitoring {
     &:after {
         content: "M";
-        width: 20px;
-        height: 20px;
+        width: 19px;
+        height: 19px;
         color: @text-color-success;
         position: absolute;
-        left: 10px;
+        right: 10px;
         text-align: center;
+        padding-left: 1px;
         border-radius: 50%;
         line-height: 20px;
     }


### PR DESCRIPTION
Moved monitoring 'M' to the right, so it doesn't overlap existing folder icons. Also centered the 'M' and fixed it's rendering.